### PR TITLE
docs: update README to describe marks reader tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ files and exports class data to more accessible CSV or spreadsheet formats.
 
 ## Project Structure
 
-- **marks_reader_python/** – Primary Python implementation and utilities for decoding and exporting marks.
+- **marks_reader_python/** - Primary Python implementation and utilities for decoding and exporting marks.
   - `marks_reader.py` – Core conversion logic that parses configuration `.txt` files, decodes Real48 floating-point values, and
     generates CSV exports.
   - `convert_to_csv.py`, `display_class.py`, `display_spreadsheet.py`, `export_to_excel.py` – Helper scripts for specific export
     or display workflows.
   - `test_marks_reader.py`, `test_decode.py` – Unit tests covering the Real48 decoder and end-to-end conversion.
   - `output/` – Example output from running the conversion scripts.
-- `README_marks_reader.md` – Detailed documentation for the Python port, including implementation notes and verification steps.
+- `README_marks_reader.md` - Detailed documentation for the Python port, including implementation notes and verification steps.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,45 @@
-# tony_main
+# Marks Reader Conversion Toolkit
+
+This repository contains a Python port of a legacy Turbo Pascal/Delphi gradebook reader. The tooling decodes `.rec` gradebook
+files and exports class data to more accessible CSV or spreadsheet formats.
+
+## Project Structure
+
+- **marks_reader_python/** – Primary Python implementation and utilities for decoding and exporting marks.
+  - `marks_reader.py` – Core conversion logic that parses configuration `.txt` files, decodes Real48 floating-point values, and
+    generates CSV exports.
+  - `convert_to_csv.py`, `display_class.py`, `display_spreadsheet.py`, `export_to_excel.py` – Helper scripts for specific export
+    or display workflows.
+  - `test_marks_reader.py`, `test_decode.py` – Unit tests covering the Real48 decoder and end-to-end conversion.
+  - `output/` – Example output from running the conversion scripts.
+- `README_marks_reader.md` – Detailed documentation for the Python port, including implementation notes and verification steps.
+
+## Getting Started
+
+1. Ensure you have Python 3.8+ installed.
+2. Navigate into `marks_reader_python/` to run the utilities.
+
+### Converting Gradebooks
+
+Use the main conversion script to process a `.rec` file alongside its accompanying `.txt` configuration file:
+
+```bash
+python marks_reader_python/marks_reader.py
+```
+
+By default the script looks for the legacy directory structure. Update the paths in `marks_reader.py` or call helper functions
+with explicit paths to match your environment.
+
+### Running Tests
+
+Execute the bundled unit tests to verify the decoder and conversion pipeline:
+
+```bash
+python -m unittest marks_reader_python/test_marks_reader.py
+python -m unittest marks_reader_python/test_decode.py
+```
+
+## Additional Resources
+
+Refer to `marks_reader_python/README_marks_reader.md` for a deep dive into the Real48 decoding algorithm, file format details,
+and validation results for the converted gradebooks.


### PR DESCRIPTION
## Summary
- expand the root README with an overview of the marks reader Python toolkit
- document project structure, conversion usage, and unit test commands

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e16a22adf4832fb5d37014f1eaf6e8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Rewrites the root README to document the Marks Reader Conversion Toolkit, including project structure, conversion usage, test commands, and references.
> 
> - **Documentation**:
>   - **Root README rewrite**: Introduces the Marks Reader Conversion Toolkit and its purpose.
>   - **Project structure**: Outlines key modules (`marks_reader_python/`, core scripts, tests, outputs).
>   - **Usage**: Adds conversion instructions and paths guidance.
>   - **Testing**: Adds unit test commands for decoder and end-to-end conversion.
>   - **References**: Points to `marks_reader_python/README_marks_reader.md` for deeper details.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb13347d2d90d0c87403b056b98caf19e5994422. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the project title in the main documentation to “Marks Reader Conversion Toolkit” for clearer branding and discoverability.
  * Improved readability by aligning the documentation header with the toolkit’s purpose; no changes to usage, features, or behavior.
  * This update affects only the displayed title in docs, ensuring users see the correct name across references without impacting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->